### PR TITLE
metrics server: report HTTP status counts

### DIFF
--- a/metrics/grpcobserver/reporter.go
+++ b/metrics/grpcobserver/reporter.go
@@ -96,6 +96,20 @@ func (obs *GRPCObserver) Report(jWriter *flatjson.Writer) error {
 			return err
 		}
 
+		for stat, value := range counts.statusEvents {
+			err = jWriter.Write(fmt.Sprintf("%s/status/%d", path, stat), value)
+			if err != nil {
+				return err
+			}
+		}
+
+		for statClass, value := range counts.statusClassEvents {
+			err = jWriter.Write(fmt.Sprintf("%s/status/%s", path, statClass), value)
+			if err != nil {
+				return err
+			}
+		}
+
 		for _, x := range []struct {
 			label string
 			val   interface{}
@@ -162,8 +176,8 @@ func (obs *GRPCObserver) GetLatencyStats() (map[string]APIEndpointStats, error) 
 }
 
 func (obs *GRPCObserver) getAPIStats() (map[string]APIEndpointStats, cumulativeCounts, error) {
-	obs.lock.Lock()
-	defer obs.lock.Unlock()
+	obs.Lock()
+	defer obs.Unlock()
 
 	apiStats := make(map[string]APIEndpointStats)
 	apiElapsedMS := make(map[string][]float64)

--- a/metrics/subject/subject.go
+++ b/metrics/subject/subject.go
@@ -44,14 +44,15 @@ const TagSep = ":"
 
 // MetricsEvent is a low level event.
 type MetricsEvent struct {
-	EventType string
-	Transport EventTransport
-	RequestID string
-	Key       string
-	PrevRoute string
-	Timestamp time.Time
-	Value     interface{}
-	Tags      []string
+	EventType  string
+	Transport  EventTransport
+	HTTPStatus int
+	RequestID  string
+	Key        string
+	PrevRoute  string
+	Timestamp  time.Time
+	Value      interface{}
+	Tags       []string
 }
 
 // Observer implements an individual observer of the observer design pattern.


### PR DESCRIPTION
Closes #172

If you can still use it, the test system is available at https://hub.docker.com/r/drfogout/metricssimple/

```bash
docker run --rm -t -p 10001:10001 -p 20001:20001 -p 30001:30001 drfogout/metricssimple
```
HTTP metrics are available from port 20001 (10001 is gRPC metrics, 30001 is metrics for the bank microservice)

```bash
$ curl localhost:20001/metrics
{
	"Total/requests": 20,
	"HTTP/requests": 20,
	"HTTPS/requests": 0,
	"RPC/requests": 0,
	"RPC_TLS/requests": 0,
	"route/acme/item/GET/requests": 12,
	"route/acme/item/GET/routes": "",
	"route/acme/item/GET/status/500": 4,
	"route/acme/item/GET/status/200": 8,
	"route/acme/item/GET/status/5XX": 4,
	"route/acme/item/GET/status/2XX": 8,
	"route/acme/item/GET/latency_ms.avg": 1272.250000,
	"route/acme/item/GET/latency_ms.count": 12,
	"route/acme/item/GET/latency_ms.max": 2724,
	"route/acme/item/GET/latency_ms.min": 1313,
	"route/acme/item/GET/latency_ms.sum": 15267,
	"route/acme/item/GET/latency_ms.p50": 1313,
	"route/acme/item/GET/latency_ms.p90": 2303,
	"route/acme/item/GET/latency_ms.p95": 2724,
	"route/acme/item/GET/latency_ms.p99": 2724,
	"route/acme/item/GET/latency_ms.p9990": 2724,
	"route/acme/item/GET/latency_ms.p9999": 2724,
	"route/acme/item/GET/errors.count": 0,
	"route/acme/item/GET/in_throughput": 0,
	"route/acme/item/GET/out_throughput": 4321,
	"route/acme/item/POST/requests": 8,
	"route/acme/item/POST/routes": "",
	"route/acme/item/POST/status/404": 3,
	"route/acme/item/POST/status/200": 5,
	"route/acme/item/POST/status/4XX": 3,
	"route/acme/item/POST/status/2XX": 5,
	"route/acme/item/POST/latency_ms.avg": 2511.000000,
	"route/acme/item/POST/latency_ms.count": 8,
	"route/acme/item/POST/latency_ms.max": 3463,
	"route/acme/item/POST/latency_ms.min": 1337,
	"route/acme/item/POST/latency_ms.sum": 20088,
	"route/acme/item/POST/latency_ms.p50": 2383,
	"route/acme/item/POST/latency_ms.p90": 3463,
	"route/acme/item/POST/latency_ms.p95": 3463,
	"route/acme/item/POST/latency_ms.p99": 3463,
	"route/acme/item/POST/latency_ms.p9990": 3463,
	"route/acme/item/POST/latency_ms.p9999": 3463,
	"route/acme/item/POST/errors.count": 0,
	"route/acme/item/POST/in_throughput": 205,
	"route/acme/item/POST/out_throughput": 0,
	"all/requests": 20,
	"all/routes": "",
	"all/status/404": 3,
	"all/status/200": 13,
	"all/status/500": 4,
	"all/status/4XX": 3,
	"all/status/2XX": 13,
	"all/status/5XX": 4,
	"all/latency_ms.avg": 1767.750000,
	"all/latency_ms.count": 20,
	"all/latency_ms.max": 3463,
	"all/latency_ms.min": 1313,
	"all/latency_ms.sum": 35355,
	"all/latency_ms.p50": 1906,
	"all/latency_ms.p90": 3048,
	"all/latency_ms.p95": 3166,
	"all/latency_ms.p99": 3463,
	"all/latency_ms.p9990": 3463,
	"all/latency_ms.p9999": 3463,
	"all/errors.count": 0,
	"all/in_throughput": 205,
	"all/out_throughput": 4321,
	"system/start_time": 1519055711228,
	"system/cpu.pct": 1.381910,
	"system/cpu_cores": 8,
	"os": "linux",
	"os_arch": "amd64",
	"system/memory/available": 24425091072,
	"system/memory/used": 9178730496,
	"system/memory/used_percent": 27.314544,
	"process/memory/used": 6949112,
	"go_metrics/runtime/sys_bytes": 6949112.000000,
	"go_metrics/runtime/malloc_count": 17910.000000,
	"go_metrics/runtime/free_count": 957.000000,
	"go_metrics/runtime/heap_objects": 16953.000000,
	"go_metrics/runtime/total_gc_pause_ns": 0.000000,
	"go_metrics/runtime/total_gc_runs": 0.000000,
	"go_metrics/runtime/num_goroutines": 13.000000,
	"go_metrics/runtime/alloc_bytes": 1738424.000000,
	"go_metrics/GET": 0.000000,
	"go_metrics/POST": 0.000000,
	"go_metrics/sendCatalog": 13.000000,
	"go_metrics/orderItem/**invalid**": 3.000000,
	"go_metrics/orderItem/1007": 1.000000,
	"go_metrics/orderItem/1004": 1.000000,
	"go_metrics/orderItem/1001": 2.000000,
	"go_metrics/orderItem/1002": 1.000000,
	"go_metrics/GetCatalog": 1960.420532,
	"go_metrics/OrderItem": 3166.262451
}
```
