### PR TITLE
add cloudwatch to changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.6
+
+* Add capability to emit metrics to CloudWatch
+
 ## 0.1.5
 
 * Show off Go Report Card


### PR DESCRIPTION
Adding CloudWatch metrics capability to the changelog and tagging 0.1.6 so services that need it can accurately track.  

Closes #260 